### PR TITLE
Add trailing comma linting rule

### DIFF
--- a/javascript/rules/base.js
+++ b/javascript/rules/base.js
@@ -11,6 +11,7 @@ module.exports = {
         "keyword-spacing": ["error", { "before": true, "after": true }],
         "array-bracket-spacing": ["error", "always"],
         "object-curly-spacing": ["error", "always"],
+        "comma-dangle": ["warn", "always-multiline"],
 
         // [Nov 27, 2019] @chris.skoblenick: commented out the quotes enforecement for now; 
         // REASON: will cause massive monorepo changes; need to incorporate once most PRs merged.

--- a/javascript/rules/base.md
+++ b/javascript/rules/base.md
@@ -10,6 +10,7 @@ We have selected the [recommended](https://eslint.org/docs/rules/) rule set.  De
 * [[object-curly-spacing]](https://eslint.org/docs/rules/object-curly-spacing) | ERROR | Provides consistent spacing around object properties in object literals and destructured objects. This received 100% concensus from the front-end team at the time of addition and especially helps us in JSX as we commonly destructure component props.
 * [[quotes]](https://eslint.org/docs/rules/quotes) | ERROR | Prefer to use single quotes in strings except where interpolating with backticks.
 * [[jsx-quotes]](https://eslint.org/docs/rules/jsx-quotes) | ERROR | Always use double-quotes in attributes.
+* [[comma-dangle]](https://eslint.org/docs/rules/jsx-quotes) | WARN | Prefer trailing commas when array / object elements are on multiple lines to improve clarity of diffs, prefer no trailing commas when everything is on one line.
 
 
 <!-- 


### PR DESCRIPTION
[https://eslint.org/docs/rules/comma-dangle](https://eslint.org/docs/rules/comma-dangle)

> "always-multiline" requires trailing commas when the last element or property is in a different line than the closing ] or } and disallows trailing commas when the last element or property is on the same line as the closing ] or }

"always-multiline" won [the slack poll](https://ratehub.slack.com/archives/CA8N86VR6/p1579881571026300)