### PR TITLE
[max-len] Add rule and description for max-len: line length enforcement

### DIFF
--- a/javascript/rules/base.js
+++ b/javascript/rules/base.js
@@ -16,7 +16,7 @@ module.exports = {
             "code": 110,
             "ignoreUrls": true,
             "ignoreStrings": true,
-            "ignoreTemplateLiterals": true
+            "ignoreTemplateLiterals": true,
         }],
 
         // [Nov 27, 2019] @chris.skoblenick: commented out the quotes enforecement for now;

--- a/javascript/rules/base.js
+++ b/javascript/rules/base.js
@@ -12,8 +12,14 @@ module.exports = {
         "array-bracket-spacing": ["error", "always"],
         "object-curly-spacing": ["error", "always"],
         "comma-dangle": ["warn", "always-multiline"],
+        "max-len": ["error", {
+            "code": 110,
+            "ignoreUrls": true,
+            "ignoreStrings": true,
+            "ignoreTemplateLiterals": true
+        }],
 
-        // [Nov 27, 2019] @chris.skoblenick: commented out the quotes enforecement for now; 
+        // [Nov 27, 2019] @chris.skoblenick: commented out the quotes enforecement for now;
         // REASON: will cause massive monorepo changes; need to incorporate once most PRs merged.
         // "quotes": ["error", "single"],
         // "jsx-quotes": ["error", "prefer-double"],
@@ -23,7 +29,7 @@ module.exports = {
         // "no-await-in-loop" : "warn",
         // "no-compare-neg-zero" : "error",
 
-        // "accessor-pairs" : ["error", {"setWithoutGet" : true, "getWithoutSet" : false}], 
+        // "accessor-pairs" : ["error", {"setWithoutGet" : true, "getWithoutSet" : false}],
     }
 
 }

--- a/javascript/rules/base.md
+++ b/javascript/rules/base.md
@@ -11,6 +11,7 @@ We have selected the [recommended](https://eslint.org/docs/rules/) rule set.  De
 * [[quotes]](https://eslint.org/docs/rules/quotes) | ERROR | Prefer to use single quotes in strings except where interpolating with backticks.
 * [[jsx-quotes]](https://eslint.org/docs/rules/jsx-quotes) | ERROR | Always use double-quotes in attributes.
 * [[comma-dangle]](https://eslint.org/docs/rules/jsx-quotes) | WARN | Prefer trailing commas when array / object elements are on multiple lines to improve clarity of diffs, prefer no trailing commas when everything is on one line.
+* [[max-len]](https://eslint.org/docs/rules/max-len) | ERROR | Line lengths may not exceed 110 characters, with exceptions provided for URLs, strings, nad template literals.
 
 
 <!-- 

--- a/javascript/rules/base.md
+++ b/javascript/rules/base.md
@@ -11,7 +11,7 @@ We have selected the [recommended](https://eslint.org/docs/rules/) rule set.  De
 * [[quotes]](https://eslint.org/docs/rules/quotes) | ERROR | Prefer to use single quotes in strings except where interpolating with backticks.
 * [[jsx-quotes]](https://eslint.org/docs/rules/jsx-quotes) | ERROR | Always use double-quotes in attributes.
 * [[comma-dangle]](https://eslint.org/docs/rules/jsx-quotes) | WARN | Prefer trailing commas when array / object elements are on multiple lines to improve clarity of diffs, prefer no trailing commas when everything is on one line.
-* [[max-len]](https://eslint.org/docs/rules/max-len) | ERROR | Line lengths may not exceed 110 characters, with exceptions provided for URLs, strings, nad template literals.
+* [[max-len]](https://eslint.org/docs/rules/max-len) | ERROR | Line lengths may not exceed 110 characters, with exceptions provided for URLs, strings, and template literals.
 
 
 <!-- 


### PR DESCRIPTION
Adds the following rule to **base.js**
```
        "max-len": ["error", {
            "code": 110,
            "ignoreUrls": true,
            "ignoreStrings": true,
            "ignoreTemplateLiterals": true,
        }],
```