### PR TITLE
feat(ccdep-2469): Create Node style package

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *               @chris-skoblenick
+*               @foster36

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,8 +6,10 @@ on:
     # Only attempt publish when the package.json has changed
     paths:
       - 'javascript/**'
+      - 'typescript/**'
       - 'css/**'
       - 'react/**'
+      - 'node/**'
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/javascript/README.md
+++ b/javascript/README.md
@@ -1,4 +1,4 @@
-# RateHub React Style guide
+# Ratehub React Style Guide
 *Javascript coding style focusing on readability and maintainability*
 
 ## Statement of Purpose

--- a/javascript/rules/base.js
+++ b/javascript/rules/base.js
@@ -12,7 +12,6 @@ module.exports = {
         "comma-dangle": ["warn", "always-multiline"],
 
         "quotes": ["error", "single"],
-        "jsx-quotes": ["error", "prefer-double"],
         "no-multi-spaces": ["error", { "ignoreEOLComments": true }],
 
         "multiline-ternary": ["error", "always-multiline"],

--- a/javascript/rules/base.md
+++ b/javascript/rules/base.md
@@ -6,28 +6,27 @@ We have selected the [recommended](https://eslint.org/docs/rules/) rule set.  De
 * [[indent]](https://eslint.org/docs/rules/indent): an internal vote was held, and the winner was `4 spaces` (5 votes).  2nd place was 3 spaces (4 votes).  Tabs & 2 spaces each received 2 votes. [SwitchCase](https://eslint.org/docs/rules/indent#switchcase) has also been set to 1 to be more idiomatic with most programming languages.
 * [[no-console]](https://eslint.org/docs/rules/no-console): this has been downgraded to `warn`, as `console` statements are used frequently during development and validation, with full intention to be removed prior to production deployment.  An often-used work-around is to just add ESLint ignore to the console statements, but that makes it much more difficult to later identify the console statements for later removal.  By keeping them as warnings, it will not fail testing, but can be easily recognized as needing to be fixed prior to final deployment.
 * [[keyword-spacing]](https://eslint.org/docs/rules/keyword-spacing): ERROR | All Javascript keywords must be preceded and followed by exactly one space character. This rule was enabled mainly to prevent developers from excluding the space between the keyword and the parenthesized condition in an `if` statement. However, it provides consistent spacing around all keywords. Keywords not surrounded by spaces can easily be misinterpreted (`if(condition)` looks somewhat like a function call to some).
-* [[array-bracket-spacing]](https://eslint.org/docs/rules/array-bracket-spacing) | ERROR | Provides consistent spacing around array members in array literals and destructured arrays. This received 100% concensus from the front-end team at the time of addition and is the array equivalent of our rule for `object-curly-spacing`.
-* [[object-curly-spacing]](https://eslint.org/docs/rules/object-curly-spacing) | ERROR | Provides consistent spacing around object properties in object literals and destructured objects. This received 100% concensus from the front-end team at the time of addition and especially helps us in JSX as we commonly destructure component props.
+* [[array-bracket-spacing]](https://eslint.org/docs/rules/array-bracket-spacing) | ERROR | Provides consistent spacing around array members in array literals and destructured arrays. This received 100% consensus from the front-end team at the time of addition and is the array equivalent of our rule for `object-curly-spacing`.
+* [[object-curly-spacing]](https://eslint.org/docs/rules/object-curly-spacing) | ERROR | Provides consistent spacing around object properties in object literals and destructured objects. This received 100% consensus from the front-end team at the time of addition and especially helps us in JSX as we commonly destructure component props.
 * [[quotes]](https://eslint.org/docs/rules/quotes) | ERROR | Prefer to use single quotes in strings except where interpolating with backticks.
-* [[jsx-quotes]](https://eslint.org/docs/rules/jsx-quotes) | ERROR | Always use double-quotes in attributes.
 * [[comma-dangle]](https://eslint.org/docs/rules/jsx-quotes) | WARN | Prefer trailing commas when array / object elements are on multiple lines to improve clarity of diffs, prefer no trailing commas when everything is on one line.
 * [[no-multi-spaces]](https://eslint.org/docs/rules/no-multi-spaces) | ERROR | Multiple spaces when not used as indentation are almost always typos and should be avoided.
 * [[multiline-ternary]](https://eslint.org/docs/latest/rules/multiline-ternary) | ERROR | Ternaries are easier to read when the "?"/":" are on separate lines.
 * [[operator-linebreak]](https://eslint.org/docs/latest/rules/operator-linebreak#before) | WARN | When doing operations across multiple lines, it's important to understand the operator which connects the line with the previous ones. When left at the end of the previous line, this is easy to miss and not available at a glance.
 
 ## Rule Notes
-* [[max-len]](https://eslint.org/docs/rules/max-len) | We had this warn on 120, however there are common cases (especially within JSX) where there is significant indenting, leading to the author having to format their code in a hard-to-read manner just to satisfy this rule. It was decided that this is best done by goveranance during code reviews, rather than an automated rule.
+* [[max-len]](https://eslint.org/docs/rules/max-len) | We had this warn on 120, however there are common cases (especially within JSX) where there is significant indenting, leading to the author having to format their code in a hard-to-read manner just to satisfy this rule. It was decided that this is best done by governance during code reviews, rather than an automated rule.
 
 
 <!-- 
 | Rule Name | Class | Discussion |
 | --- | :---: | --- |
 | [[for-direction]](https://eslint.org/docs/rules/for-direction) | OFF | While it is suggested that any non-forward iteration require a comment pointing out the deviation to the developer, there are many cases where backward iteration is desired and a clearer way of implementation a solution |
-| [[getter-return]](https://eslint.org/docs/rules/getter-return) | ERROR | Every `get` can reasonabily be expected to return a value.  No return is likely an unintended omission |
-| [[no-await-in-loop]](https://eslint.org/docs/rules/no-await-in-loop) | WARN | Syncronously looping over a set with an await on each operation likely not the original intention of the author; they likely wanted to `await` completion of a set of operations.  This may be upgraded to an `error` at a later point.
+| [[getter-return]](https://eslint.org/docs/rules/getter-return) | ERROR | Every `get` can reasonably be expected to return a value.  No return is likely an unintended omission |
+| [[no-await-in-loop]](https://eslint.org/docs/rules/no-await-in-loop) | WARN | Synchronously looping over a set with an await on each operation likely not the original intention of the author; they likely wanted to `await` completion of a set of operations.  This may be upgraded to an `error` at a later point.
 | [[no-compare-neg-zero]](https://eslint.org/docs/rules/no-compare-neg-zero) | ERROR | this makes code more confusing to read with no benefit |
-| [[no-cond-assign]](https://eslint.org/docs/rules/no-cond-assign) | ERROR | this is likely not indended, and caught as a likely typo |
+| [[no-cond-assign]](https://eslint.org/docs/rules/no-cond-assign) | ERROR | this is likely not intended, and caught as a likely typo |
 
 
 
-| [[accessor-pairs]](https://eslint.org/docs/rules/accessor-pairs) | ERROR | Providing a `set` without a `get` is very unintuative.  In any case where this type of behaviour is desired, use a `function` instead. | -->
+| [[accessor-pairs]](https://eslint.org/docs/rules/accessor-pairs) | ERROR | Providing a `set` without a `get` is very unintuitive.  In any case where this type of behaviour is desired, use a `function` instead. | -->

--- a/node/README.md
+++ b/node/README.md
@@ -1,0 +1,11 @@
+# Ratehub Node Style Guide
+*Node coding style focusing on readability and maintainability*
+
+## Statement of Purpose
+The severity/classification of each rule is driver by 3 primary drivers:
+* catching mistakes
+* preventing bad design (easier to change/maintain)
+* minimizing code complexity (easier to read)
+
+## Suggesting Changes
+If disagreement with a rule's classification or changes to the plugins chosen are desired, please open a [ticket](https://github.com/ratehub/code-style/issues).  Pull requests against this repository require changes to the associated markup document so the rationale and rule configuration will stay in-sync.

--- a/node/index.js
+++ b/node/index.js
@@ -1,0 +1,8 @@
+module.exports = {
+
+   "extends": [
+     './rules/javascript',
+     './rules/typescript'
+   ].map(require.resolve),
+
+ };

--- a/node/package.json
+++ b/node/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@ratehub/eslint-config-node",
+  "version": "1.0.0",
+  "description": "A set of linting rules for Ratehub projects using Node.js",
+  "main": "index.js",
+  "scripts": {
+    "release": "semantic-release --tag-format='${process.env.npm_package_name}-${version}'",
+    "release:dry": "semantic-release --dry-run --branches `git branch --show-current` --tag-format='${process.env.npm_package_name}-${version}'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ratehub/code-style"
+  },
+  "bugs": {
+    "url": "https://github.com/ratehub/code-style/issues"
+  },
+  "homepage": "https://github.com/ratehub/code-style",
+  "keywords": [
+    "ratehub",
+    "eslint",
+    "eslintconfig",
+    "node"
+  ],
+  "author": "Jacob Foster",
+  "license": "MIT",
+  "peerDependencies": {
+    "@babel/eslint-parser": "^7.18.9",
+    "@ratehub/eslint-config-js": "^3.0.0",
+    "@ratehub/eslint-config-ts": "^1.0.0",
+    "@typescript-eslint/parser": "^5.45.0",
+    "eslint": ">= 8"
+  },
+  "devDependencies": {
+    "@semantic-release/commit-analyzer": "^9.0.2",
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^8.0.5",
+    "@semantic-release/npm": "^9.0.1",
+    "@semantic-release/release-notes-generator": "^10.0.3",
+    "semantic-release": "^19.0.3",
+    "semantic-release-monorepo": "^7.0.5"
+  }
+}

--- a/node/rules/javascript.js
+++ b/node/rules/javascript.js
@@ -1,0 +1,23 @@
+module.exports = {
+    "extends": [
+        "@ratehub/eslint-config-js",
+    ],
+
+    // Using the default parser will cause issues with arrow-declared functions.
+    "parser": "@babel/eslint-parser",
+
+    "parserOptions": {
+        "sourceType": "module",
+        "ecmaVersion": 2017,
+        "ecmaFeatures": {
+            "jsx": true,
+            "modules": true,
+            "experimentalObjectRestSpread": true,
+        }
+    },
+
+    "rules": {
+        "max-len": ["error", {"code": 120, "ignorePattern": true, "ignoreUrls": true, "ignoreStrings": true, "ignoreRegExpLiterals": true}],
+        "semi": ["error", "always"],
+    }
+};

--- a/node/rules/javascript.md
+++ b/node/rules/javascript.md
@@ -1,0 +1,7 @@
+
+## Configuration Selected
+We have extended the default [Ratehub](https://github.com/ratehub/code-style/tree/master/javascript/rules) rule set. Deviations from the rule set will be discussed below.
+
+## Rule Deviations
+* [[max-len]](https://eslint.org/docs/rules/max-len) | ERROR | Limit line length to 120 characters, except for strings, URLs, and regular expressions.
+* [[semi]](https://eslint.org/docs/rules/semi) | ERROR | Always use semicolons at the end of statements.

--- a/node/rules/typescript.js
+++ b/node/rules/typescript.js
@@ -1,0 +1,18 @@
+module.exports = {
+    "extends": [
+        "@ratehub/eslint-config-ts",
+    ],
+
+    "parser": "@typescript-eslint/parser",
+
+    "parserOptions": {
+        "ecmaVersion": 2017,
+        "lib": ["ES2017"]
+    },
+
+    "rules": {
+        "max-len": ["error", {"code": 120, "ignorePattern": true, "ignoreUrls": true, "ignoreStrings": true, "ignoreRegExpLiterals": true}],
+        "semi": "off",
+        "@typescript-eslint/semi": "error"
+    }
+};

--- a/node/rules/typescript.md
+++ b/node/rules/typescript.md
@@ -1,0 +1,8 @@
+
+## Configuration Selected
+We have extended the default [Ratehub](https://github.com/ratehub/code-style/tree/master/typescript/rules) rule set. Deviations from the rule set will be discussed below.
+
+## Rule Deviations
+* [[max-len]](https://eslint.org/docs/rules/max-len) | ERROR | Limit line length to 120 characters, except for strings, URLs, and regular expressions.
+* [[semi]](https://eslint.org/docs/rules/semi) | OFF | Base rule disabled as it can report incorrect errors with the `@typescript-eslint/semi` rule enabled.
+* [[@typescript-eslint/semi]](https://typescript-eslint.io/rules/semi) | ERROR | Always use semicolons at the end of statements.

--- a/react/index.js
+++ b/react/index.js
@@ -25,8 +25,8 @@ module.exports = {
    },
 
    "extends": [
-     '@ratehub/eslint-config-js',
      './rules/react',
+     './rules/javascript',
      './rules/jsx-a11y',
      './rules/jsx-control-statements'
    ].map(require.resolve),

--- a/react/rules/javascript.js
+++ b/react/rules/javascript.js
@@ -1,0 +1,9 @@
+module.exports = {
+    "extends": [
+        "@ratehub/eslint-config-js",
+    ],
+
+    "rules": {
+        "jsx-quotes": ["error", "prefer-double"],
+    }
+}

--- a/react/rules/javascript.md
+++ b/react/rules/javascript.md
@@ -1,0 +1,6 @@
+
+## Configuration Selected
+We have extended the default [Ratehub](https://github.com/ratehub/code-style/tree/master/javascript/rules) rule set.  Deviations from the rule set will be discussed below.
+
+## Rule Deviations
+* [[jsx-quotes]](https://eslint.org/docs/rules/jsx-quotes) | ERROR | Always use double-quotes in attributes.

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -17,4 +17,3 @@ Use `interface`:
 Use `type`:
 * when you are defining typing information for things like local state, parameters, custom return types
 * `type` suggests this is just providing typing information for TS, and I don't need to worry about many different implementers of the same signature.
-* 

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -1,0 +1,14 @@
+module.exports = {
+
+   "parser": "@typescript-eslint/parser",
+
+   "parserOptions": {
+      "ecmaVersion": 2017,
+      "lib": ["ES2017"]
+   },
+
+   "extends": [
+     './rules/base'
+   ].map(require.resolve),
+
+ };

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@ratehub/eslint-config-ts",
+  "version": "1.0.0",
+  "description": "ESLint config for use on Ratehub TypeScript projects",
+  "main": "index.js",
+  "scripts": {
+    "release": "semantic-release --tag-format='${process.env.npm_package_name}-${version}'",
+    "release:dry": "semantic-release --dry-run --branches `git branch --show-current` --tag-format='${process.env.npm_package_name}-${version}'"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ratehub/code-style"
+  },
+  "bugs": {
+    "url": "https://github.com/ratehub/code-style/issues"
+  },
+  "homepage": "https://github.com/ratehub/code-style",
+  "keywords": [
+    "ratehub",
+    "eslint",
+    "eslintconfig",
+    "typescript"
+  ],
+  "author": "Jacob Foster",
+  "license": "MIT",
+  "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.45.0",
+    "@typescript-eslint/parser": "^5.45.0",
+    "eslint": ">= 8",
+    "typescript": "^4.9.3"
+  },
+  "devDependencies": {
+    "@semantic-release/commit-analyzer": "^9.0.2",
+    "@semantic-release/git": "^10.0.1",
+    "@semantic-release/github": "^8.0.5",
+    "@semantic-release/npm": "^9.0.1",
+    "@semantic-release/release-notes-generator": "^10.0.3",
+    "semantic-release": "^19.0.3",
+    "semantic-release-monorepo": "^7.0.5"
+  }
+}

--- a/typescript/rules/base.js
+++ b/typescript/rules/base.js
@@ -1,0 +1,10 @@
+module.exports = {
+    "extends": [
+        "eslint:recommended",
+        "plugin:@typescript-eslint/recommended"
+    ],
+
+    "plugins": [
+        "@typescript-eslint"
+    ]
+};

--- a/typescript/rules/base.md
+++ b/typescript/rules/base.md
@@ -1,0 +1,5 @@
+
+## Configuration Selected
+We have selected the recommended rule sets for [ESLint](https://eslint.org/docs/rules/) and [TypeScript](https://typescript-eslint.io/rules).  Deviations from the rule set will be discussed below.
+
+## Rule Deviations

--- a/typescript/rules/base.md
+++ b/typescript/rules/base.md
@@ -1,5 +1,5 @@
 
 ## Configuration Selected
-We have selected the recommended rule sets for [ESLint](https://eslint.org/docs/rules/) and [TypeScript](https://typescript-eslint.io/rules).  Deviations from the rule set will be discussed below.
+We have selected the recommended rule sets for [ESLint](https://eslint.org/docs/rules/) and [TypeScript](https://typescript-eslint.io/rules). Deviations from the rule set will be discussed below.
 
 ## Rule Deviations


### PR DESCRIPTION
https://ratehub.atlassian.net/browse/CCDEP-2469

- Moves frontend-specific rules from `javascript` package to `react` package
- Creates new `typescript` rules, starting with recommended defaults
- Creates new `node` package, extending `javascript` + `typescript` and adding backend-specific rules