### PR TITLE
fix(ccdep-2469): Trigger builds + use latest

### DIFF
--- a/javascript/index.js
+++ b/javascript/index.js
@@ -5,7 +5,7 @@ module.exports = {
 
    "parserOptions": {
       "sourceType": "module",
-      "ecmaVersion": 2017,
+      "ecmaVersion": 2022,
       "ecmaFeatures": {
          "modules": true,
          "experimentalObjectRestSpread": true

--- a/node/index.js
+++ b/node/index.js
@@ -2,7 +2,7 @@ module.exports = {
 
    "extends": [
      './rules/javascript',
-     './rules/typescript'
+     './rules/typescript',
    ].map(require.resolve),
 
  };

--- a/node/package.json
+++ b/node/package.json
@@ -25,8 +25,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/eslint-parser": "^7.18.9",
-    "@ratehub/eslint-config-js": "^3.4.0",
-    "@ratehub/eslint-config-ts": "^1.0.1",
+    "@ratehub/eslint-config-js": "^3.4.1",
+    "@ratehub/eslint-config-ts": "^1.0.0",
     "@typescript-eslint/parser": "^5.45.0",
     "eslint": ">= 8"
   },

--- a/node/package.json
+++ b/node/package.json
@@ -25,8 +25,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/eslint-parser": "^7.18.9",
-    "@ratehub/eslint-config-js": "^3.0.0",
-    "@ratehub/eslint-config-ts": "^1.0.0",
+    "@ratehub/eslint-config-js": "^3.4.0",
+    "@ratehub/eslint-config-ts": "^1.0.1",
     "@typescript-eslint/parser": "^5.45.0",
     "eslint": ">= 8"
   },

--- a/node/rules/javascript.js
+++ b/node/rules/javascript.js
@@ -8,7 +8,7 @@ module.exports = {
 
     "parserOptions": {
         "sourceType": "module",
-        "ecmaVersion": 2017,
+        "ecmaVersion": 2022,
         "ecmaFeatures": {
             "jsx": true,
             "modules": true,

--- a/node/rules/typescript.js
+++ b/node/rules/typescript.js
@@ -6,8 +6,8 @@ module.exports = {
     "parser": "@typescript-eslint/parser",
 
     "parserOptions": {
-        "ecmaVersion": 2017,
-        "lib": ["ES2017"]
+        "ecmaVersion": 2022,
+        "lib": ["ES2022"]
     },
 
     "rules": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "workspaces": [
         "css",
         "react",
-        "javascript"
+        "node",
+        "javascript",
+        "typescript"
     ],
     "scripts": {
         "release": "semantic-release",

--- a/react/index.js
+++ b/react/index.js
@@ -5,7 +5,7 @@ module.exports = {
 
    "parserOptions": {
       "sourceType": "module",
-      "ecmaVersion": 2017,
+      "ecmaVersion": 2022,
       "ecmaFeatures": {
          "jsx": true,
          "modules": true,

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/eslint-parser": "^7.18.9",
-    "@ratehub/eslint-config-js": "^3.0.0",
+    "@ratehub/eslint-config-js": "^3.4.0",
     "eslint": ">= 8",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-jsx-control-statements": "^3.0.0",

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/eslint-parser": "^7.18.9",
-    "@ratehub/eslint-config-js": "^3.4.0",
+    "@ratehub/eslint-config-js": "^3.4.1",
     "eslint": ">= 8",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-jsx-control-statements": "^3.0.0",

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -3,8 +3,8 @@ module.exports = {
    "parser": "@typescript-eslint/parser",
 
    "parserOptions": {
-      "ecmaVersion": 2017,
-      "lib": ["ES2017"],
+      "ecmaVersion": 2022,
+      "lib": ["ES2022"],
    },
 
    "extends": [

--- a/typescript/index.js
+++ b/typescript/index.js
@@ -4,7 +4,7 @@ module.exports = {
 
    "parserOptions": {
       "ecmaVersion": 2017,
-      "lib": ["ES2017"]
+      "lib": ["ES2017"],
    },
 
    "extends": [


### PR DESCRIPTION
- Trigger builds for new `node` + `typescript` packages
- Use latest packages in `node` + `react` packages