### PR TITLE
chore(ccdep-2469): Fix JS versions

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -25,7 +25,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/eslint-parser": "^7.18.9",
-    "@ratehub/eslint-config-js": "^3.4.1",
+    "@ratehub/eslint-config-js": "^3.4.0",
     "@ratehub/eslint-config-ts": "^1.0.0",
     "@typescript-eslint/parser": "^5.45.0",
     "eslint": ">= 8"

--- a/react/package.json
+++ b/react/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@babel/eslint-parser": "^7.18.9",
-    "@ratehub/eslint-config-js": "^3.4.1",
+    "@ratehub/eslint-config-js": "^3.4.0",
     "eslint": ">= 8",
     "eslint-plugin-jsx-a11y": "^6.6.1",
     "eslint-plugin-jsx-control-statements": "^3.0.0",


### PR DESCRIPTION
Was trying to deploy a new version of the JS package and use it in the same PR. This rolls back the JS version so the new one can be built before using it.