### PR TITLE
fix(typescript): disable explicit-any plugin

### DIFF
--- a/typescript/rules/base.js
+++ b/typescript/rules/base.js
@@ -3,8 +3,10 @@ module.exports = {
         "eslint:recommended",
         "plugin:@typescript-eslint/recommended"
     ],
-
+    "rules": {
+        "@typescript-eslint/no-explicit-any": "0"
+    },
     "plugins": [
         "@typescript-eslint"
-    ]
+    ],
 };


### PR DESCRIPTION
Based on a slack thread we aren't ready for explicit any. Internal new code should use types, but old code and libraries shouldn't have to add types in order to be migrated

refs: https://ratehub.slack.com/archives/C04BZ8W3BPT/p1690200678261639