### PR TITLE
feat(typescript): Support typescript 5.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         },
         "javascript": {
             "name": "@ratehub/eslint-config-js",
-            "version": "3.4.1",
+            "version": "3.5.1",
             "license": "MIT",
             "devDependencies": {
                 "@semantic-release/commit-analyzer": "^9.0.2",
@@ -56,7 +56,7 @@
         },
         "node": {
             "name": "@ratehub/eslint-config-node",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "license": "MIT",
             "devDependencies": {
                 "@semantic-release/commit-analyzer": "^9.0.2",
@@ -11899,7 +11899,7 @@
         },
         "react": {
             "name": "@ratehub/eslint-config-react",
-            "version": "3.3.1",
+            "version": "3.3.2",
             "license": "MIT",
             "devDependencies": {
                 "@semantic-release/commit-analyzer": "^9.0.2",
@@ -11921,7 +11921,7 @@
         },
         "typescript": {
             "name": "@ratehub/eslint-config-ts",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "license": "MIT",
             "devDependencies": {
                 "@semantic-release/commit-analyzer": "^9.0.2",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -21,13 +21,13 @@
     "eslintconfig",
     "typescript"
   ],
-  "author": "Jacob Foster",
+  "author": "Ratehub <dev@ratehub.ca> (https://www.ratehub.ca)",
   "license": "MIT",
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.45.0",
-    "@typescript-eslint/parser": "^5.45.0",
+    "@typescript-eslint/eslint-plugin": "^5.45.0 || ^6.14.0",
+    "@typescript-eslint/parser": "^5.45.0 || ^6.14.0",
     "eslint": ">= 8",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.3 || ^5.2.2"
   },
   "devDependencies": {
     "@semantic-release/commit-analyzer": "^9.0.2",


### PR DESCRIPTION
Want to use typescript 5.x in the microservices monorepo. Using `||` should allow us to support both 4 and 5 at the same time